### PR TITLE
[backend] TODO and support multiple return in the assmebly.

### DIFF
--- a/TODO
+++ b/TODO
@@ -74,3 +74,7 @@ Test framework: Refer the NOTES in the 'tests/' directory
 - [ ] User defined compile time directives as attributes
 - [ ] Exposure of compiler plugin meaning the user can create event pull
       based compiler plugins instead of jai's message push style one.
+
+- [ ] Alloca does not take into account for function frame so if a function returns multiple returns
+      Fix stack allocation to allocate new memory depeding of the stack frame slot provided by the function.
+- [ ] Not emit obj and asm crap in the same dir put it in its own separate userspace directory.

--- a/src/backend/st_nasm_x86_64_linux.c
+++ b/src/backend/st_nasm_x86_64_linux.c
@@ -101,7 +101,11 @@ static void ST_generate_inst(FILE *out, ST_ir_inst_t *in)
         fprintf(out, "    imul rax, rcx\n");
     } break;
     case ST_IR_SDIV: ST_todo("ST_IR_SDIV"); break;
-    case ST_IR_EXTRACT_OP: ST_todo("ST_IR_EXTRACT_OP"); break;
+    case ST_IR_EXTRACT_OP: {
+        if (in->extract.index == 0) ST_load(out, "rax", in->extract.agg);
+        else if (in->extract.index == 1) fprintf(out, "    mov rax, rdx\n");
+        else ST_todo("Multiple call return not implemented");
+    } break;
     case ST_IR_UDIV: ST_todo("ST_IR_UDIV"); break;
     case ST_IR_SREM: ST_todo("ST_IR_SREM"); break;
     case ST_IR_UREM: ST_todo("ST_IR_UREM"); break;
@@ -231,7 +235,9 @@ static void ST_generate_term(FILE *out, ST_ir_block_t *b)
     switch (t->kind)
     {
     case ST_IR_TERM_RET: {
-        if (t->rets.count) ST_load(out, "rax", t->rets.items[0]);
+        if (t->rets.count >= 1) ST_load(out, "rax", t->rets.items[0]);
+        if (t->rets.count >= 2) ST_load(out, "rdx", t->rets.items[1]);
+        if (t->rets.count > 2) ST_todo("Not implemented");
         fprintf(out, "    leave\n");
         fprintf(out, "    ret\n");
     } break;


### PR DESCRIPTION
Since I did not account for stack frame of alloca it will always reassign the same place and get referenced.