### PR TITLE
[semantic] Fix lowering untyped literal.

### DIFF
--- a/src/backend/st_nasm_x86_64_linux.c
+++ b/src/backend/st_nasm_x86_64_linux.c
@@ -227,7 +227,7 @@ static void ST_generate_inst(FILE *out, ST_gen_ctx_t *ctx, ST_ir_inst_t *in)
     case ST_IR_FCMP_GE: ST_todo("ST_IR_FCMP_GE"); break;
     case ST_IR_CAST: ST_todo("ST_IR_CAST"); break;
     case ST_IR_PARAM: {
-        if (in->ty && in->ty->kind == ST_TY_FLOAT)
+        if (in->ty && ST_ty_is_float(in->ty))
         {
             if (ctx->next_float_arg >= ST_N_XMM_REGS) ST_todo("too many float parameters");
             fprintf(out, "movsd xmm0m %s\n", xmm_regs[ctx->next_float_arg]);
@@ -255,7 +255,7 @@ static void ST_generate_inst(FILE *out, ST_gen_ctx_t *ctx, ST_ir_inst_t *in)
         ST_forrange(0, in->call.args.count)
         {
             ST_ir_inst_t *arg = in->call.args.items[i];
-            if (arg->ty && arg->ty->kind == ST_TY_FLOAT)
+            if (arg->ty && ST_ty_is_float(arg->ty))
             {
                 if (float_idx >= ST_N_XMM_REGS) ST_todo("too many float arguments");
                 ST_fload(out, xmm_regs[float_idx], arg);
@@ -287,18 +287,22 @@ static void ST_generate_inst(FILE *out, ST_gen_ctx_t *ctx, ST_ir_inst_t *in)
     } break;
     case ST_IR_LOAD: {
         ST_load(out, "rcx", in->load.addr);
-        if (in->ty && in->ty->kind == ST_TY_FLOAT)
+        if (in->ty && ST_ty_is_float(in->ty))
+        {
             if (in->ty->size == 4)
             {
                 fprintf(out, "    movss xmm0, [rcx]\n");
                 fprintf(out, "    cvtss2sd xmm0, xmm0\n");
             }
-            else fprintf(out, "    movsd xmm0, [rcx]\n");
+            else {
+                fprintf(out, "    movsd xmm0, [rcx]\n");
+            }
+        }
         else
             ST_mem_load(out, in->ty);
     } break;
     case ST_IR_STORE: {
-        if (in->ty && in->ty->kind == ST_TY_FLOAT)
+        if (in->ty && ST_ty_is_float(in->ty))
         {
             ST_fload(out, "xmm0", in->store.v);
             ST_load(out, "rcx", in->store.addr);
@@ -337,7 +341,7 @@ static void ST_generate_inst(FILE *out, ST_gen_ctx_t *ctx, ST_ir_inst_t *in)
     }
     if (in->ty && in->ty->kind != ST_TY_VOID)
     {
-        if (in->ty->kind == ST_TY_FLOAT)
+        if (ST_ty_is_float(in->ty))
             fprintf(out, "    movsd [rbp%+d], xmm0\n", ST_slot(in));
         else
         fprintf(out, "    mov [rbp%+d], rax\n", ST_slot(in));
@@ -400,13 +404,13 @@ static void ST_generate_term(FILE *out, ST_gen_ctx_t *ctx, ST_ir_block_t *b)
         else
         {
             if (t->rets.count >= 1) {
-                if (t->rets.items[0]->ty && t->rets.items[0]->ty->kind == ST_TY_FLOAT)
+                if (t->rets.items[0]->ty && ST_ty_is_float(t->rets.items[0]->ty))
                     ST_fload(out, "xmm0", t->rets.items[0]);
                 else
                     ST_load(out, "rax", t->rets.items[0]);
             }
             if (t->rets.count >= 2) {
-                if (t->rets.items[1]->ty && t->rets.items[1]->ty->kind == ST_TY_FLOAT)
+                if (t->rets.items[1]->ty && ST_ty_is_float(t->rets.items[1]->ty))
                     ST_fload(out, "xmm1", t->rets.items[1]);
                 else
                     ST_load(out, "rdx", t->rets.items[1]);

--- a/src/frontend/st_semantic.c
+++ b/src/frontend/st_semantic.c
@@ -109,7 +109,7 @@ static b8 ST_ty_is_layout(ST_ty_t *t)
     return t && (t->kind == ST_TY_STRUCT || t->kind == ST_TY_TAG_UNION);
 }
 
-// untyped int -> i64, untyped float -> f64;
+// untyped int -> i32, untyped float -> f32;
 static ST_ty_t *ST_ty_defaulted(ST_sema_t *se, ST_ty_t *t)
 {
     if (!t) return NULL;
@@ -1685,7 +1685,172 @@ static void ST_sema_check(ST_sema_t *se, ST_program_t *prog)
     }
 }
 
- b8 ST_sema_run(ST_arena_t *arena, ST_program_t *prog, ST_string_t src,
+// Pass 4 Typechecking
+
+static void ST_default_expr(ST_sema_t *se, ST_expr_t *e);
+static void ST_default_exprs(ST_sema_t *se, ST_exprs_t *es)
+{
+    ST_forrange(0, es->count) ST_default_expr(se, es->items[i]);
+}
+
+static void ST_default_body(ST_sema_t *se, ST_stmts_t *body);
+static void ST_default_stmt(ST_sema_t *se, ST_stmt_t *s)
+{
+    if (!s) return;
+    switch(s->kind)
+    {
+    case ST_ST_EXPR:
+        ST_default_expr(se, s->expr);
+        break;
+    case ST_ST_DECL:
+        ST_default_expr(se, s->decl.init);
+        break;
+    case ST_ST_ASSIGN:
+        ST_default_expr(se, s->assign.lhs);
+        ST_default_expr(se, s->assign.rhs);
+        break;
+    case ST_ST_MULTI_BIND:
+        ST_default_exprs(se, &s->multi.values);
+        break;
+    case ST_ST_IF:
+        ST_default_expr(se, s->if_.cond);
+        ST_default_body(se, &s->if_.then_body);
+        ST_default_stmt(se, s->if_.else_stmt);
+        break;
+    case ST_ST_SWITCH:
+        ST_default_expr(se, s->switch_.cond);
+        ST_forrange(0, s->switch_.cases.count)
+        {
+            ST_case_t *c = &s->switch_.cases.items[i];
+            ST_default_exprs(se, &c->values);
+            ST_default_body(se, &c->body);
+        }
+        break;
+    case ST_ST_WHILE:
+        ST_default_expr(se, s->while_.cond);
+        ST_default_body(se, &s->while_.body);
+        break;
+    case ST_ST_FOR_RANGE:
+        ST_default_expr(se, s->for_range.lo);
+        ST_default_expr(se, s->for_range.hi);
+        ST_default_body(se, &s->for_range.body);
+        break;
+    case ST_ST_FOR_ARRAY:
+        ST_default_expr(se, s->for_array.target);
+        ST_default_body(se, &s->for_array.body);
+        break;
+    case ST_ST_RETURN:
+        ST_default_exprs(se, &s->ret.values);
+        break;
+    case ST_ST_BLOCK:
+        ST_default_body(se, &s->block);
+        break;
+    case ST_ST_DEFER:
+        ST_default_stmt(se, s->defer_stmt);
+        break;
+    case ST_ST_BREAK:
+    case ST_ST_CONTINUE:
+    case ST_ST_LABEL:
+    case ST_ST_GODOWN:
+        break;
+    case ST_ST_COUNT:
+        ST_assert(0);
+        break;
+    }
+}
+
+static void ST_default_body(ST_sema_t *se, ST_stmts_t *body)
+{
+    ST_forrange(0, body->count) ST_default_stmt(se, body->items[i]);
+}
+
+static void ST_default_expr(ST_sema_t *se, ST_expr_t *e)
+{
+    if (!e) return;
+    e->ty = ST_ty_defaulted(se, e->ty);
+    switch(e->kind)
+    {
+    case ST_EX_INT:
+    case ST_EX_FLOAT:
+    case ST_EX_STR:
+    case ST_EX_CHAR:
+    case ST_EX_BOOL:
+    case ST_EX_NULL:
+    case ST_EX_IDENT:
+    case ST_EX_ARRAY_NEW:
+    case ST_EX_SIZEOF:
+        break;
+    case ST_EX_UNARY:
+        ST_default_expr(se, e->unary.operand);
+        break;
+    case ST_EX_BINARY:
+        ST_default_expr(se, e->bin.l);
+        ST_default_expr(se, e->bin.r);
+        break;
+    case ST_EX_CALL:
+        ST_default_expr(se, e->call.callee);
+        ST_forrange(0, e->call.args.count)
+            ST_default_expr(se, e->call.args.items[i].value);
+        break;
+    case ST_EX_FIELD:
+        ST_default_expr(se, e->field.base);
+        break;
+    case ST_EX_INDEX:
+        ST_default_expr(se, e->index.base);
+        ST_default_expr(se, e->index.index);
+        break;
+    case ST_EX_CAST:
+        ST_default_expr(se, e->cast.operand);
+        break;
+    case ST_EX_STRUCT_LIT:
+        ST_forrange(0, e->struct_lit.inits.count)
+            ST_default_expr(se, e->struct_lit.inits.items[i].value);
+        break;
+    case ST_EX_TYPEOF:
+    case ST_EX_KIND:
+    case ST_EX_CSTR:
+        ST_default_expr(se, e->tyop.operand);
+        break;
+    case ST_EX_TYPEINFO:
+        if (!e->tyop.te) ST_default_expr(se, e->tyop.operand);
+        break;
+    case ST_EX_COUNT:
+        ST_assert(0);
+        break;
+    }
+}
+
+static void ST_sema_default_types(ST_sema_t *se, ST_program_t *prog)
+{
+    ST_forrange(0, prog->decls.count)
+    {
+        ST_decl_t *d = prog->decls.items[i];
+        if (!d) continue;
+        switch(d->kind)
+        {
+        case ST_DE_CONST:
+            ST_default_expr(se, d->const_.value);
+            break;
+        case ST_DE_FN:
+            ST_forrange(0, d->fn.sig.params.count)
+                ST_default_expr(se, d->fn.sig.params.items[i].def);
+            if (!d->fn.is_prototype)
+                ST_default_body(se, &d->fn.body);
+            break;
+        case ST_DE_EXTERN_FN:
+            ST_forrange(0, d->extern_fn.sig.params.count)
+                ST_default_expr(se, d->extern_fn.sig.params.items[i].def);
+        case ST_DE_STRUCT:
+        case ST_DE_ENUM:
+        case ST_DE_TAG_UNION:
+        case ST_DE_EXTERN_VAR:
+        case ST_DE_COUNT:
+            break;
+        }
+    }
+}
+
+b8 ST_sema_run(ST_arena_t *arena, ST_program_t *prog, ST_string_t src,
                 ST_string_t file, ST_sema_t *out)
 {
     ST_sema_t *se = out;
@@ -1705,5 +1870,6 @@ static void ST_sema_check(ST_sema_t *se, ST_program_t *prog)
    ST_sema_collect(se, prog);
    ST_sema_types(se, prog);
    ST_sema_check(se, prog);
+   ST_sema_default_types(se, prog);
    return se->diag.n_errors == 0;
 }

--- a/src/middle/st_lower.c
+++ b/src/middle/st_lower.c
@@ -1088,8 +1088,8 @@ static void ST_lower_stmt(ST_lower_ctx_t *c, ST_stmt_t *s)
     case ST_ST_DECL: {
         b8 taken = ST_lower_is_addr_taken(c, s->decl.name);
 
-        ST_ty_t *ty = s->decl.init ? s->decl.init->ty
-                                   : ST_lower_tyexpr(c, s->decl.te);
+        ST_ty_t *ty = s->decl.te ? ST_lower_tyexpr(c, s->decl.te)
+            : s->decl.init ? s->decl.init->ty : NULL;
         if (!ty)
         {
             ST_diag_error(&c->diag, s->line, s->col,
@@ -1170,6 +1170,15 @@ static void ST_lower_stmt(ST_lower_ctx_t *c, ST_stmt_t *s)
             init = ST_ir_const_float(c->cur, ty, 0.0);
         else
             init = ST_ir_const_int(c->cur, ty, 0);
+
+        if (init && init->ty && init->ty != ty)
+        {
+            b8 same_repr = init->ty->size == ty->size
+                && ((ST_ty_is_int(init->ty) && ST_ty_is_int(ty))
+                    || (ST_ty_is_float(init->ty) && ST_ty_is_float(ty)));
+            if (same_repr) init->ty = ty;
+            else init = ST_ir_cast(c->cur, ty, init, s->line, s->col);
+        }
 
         if (taken)
         {


### PR DESCRIPTION
This will lower untyped literals to typed f32 or i32 depending on the context.